### PR TITLE
Use response only if there was no error

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,10 +131,10 @@ var callMethod = exports.callMethod = function (name, token, parameters, callbac
     };
     request(options, function (error, response, body) {
         if (callback) {
-            var statusCode = response.statusCode;
-            var headers = response.headers;
             var json = null;
             if (!error) {
+                var statusCode = response.statusCode;
+                var headers = response.headers;
                 var contentType = headers['content-type'];
                 if (contentType && contentType.split(';')[0] === 'application/json') {
                     json = JSON.parse(body);


### PR DESCRIPTION
Otherwise if there was an error, then the `response` is `undefined` and it will be wrong to do `response.statusCode` in that case.